### PR TITLE
Remove deprecated attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## v2.0.0 - 2020-09-28
+
+### Updated
+
+- Module has been updated because of deprecated attribute (```enable_blob_encryption```, ```enable_file_encryption``` and ```account_encryption_source```) for ```storage_account``` resource.
+
 ## v1.0.0 - 2020-01-24
+
 ### Added
+
 - Initial release
-
-## v2.0.0 - 2020-06-08
-

--- a/main.tf
+++ b/main.tf
@@ -10,10 +10,7 @@ resource "azurerm_storage_account" "this" {
   account_tier              = var.account_tier
   account_replication_type  = var.account_replication_type
   access_tier               = var.access_tier
-  enable_blob_encryption    = var.blob_encryption
-  enable_file_encryption    = var.file_encryption
   enable_https_traffic_only = var.https_traffic
-  account_encryption_source = var.account_encryption_source
 
   tags = var.tags
 }

--- a/output.tf
+++ b/output.tf
@@ -20,10 +20,6 @@ output storage_account_replication_type {
   value = azurerm_storage_account.this.account_replication_type
 }
 
-output storage_account_encryption_source {
-  value = azurerm_storage_account.this.account_encryption_source
-}
-
 output storage_account_primary_location {
   value = azurerm_storage_account.this.primary_location
 }

--- a/variables.tf
+++ b/variables.tf
@@ -44,28 +44,10 @@ variable "access_tier" {
   default     = "hot"
 }
 
-variable "blob_encryption" {
-  description = "Boolean flag which controls if Encryption Services are enabled for Blob storage."
-  type        = string
-  default     = true
-}
-
-variable "file_encryption" {
-  description = "Boolean flag which controls if Encryption Services are enabled for File storage."
-  type        = string
-  default     = true
-}
-
 variable "https_traffic" {
   description = "Boolean flag which forces HTTPS if enabled"
   type        = string
   default     = true
-}
-
-variable "account_encryption_source" {
-  description = "The Encryption Source for this Storage Account. Possible values are Microsoft.Keyvault and Microsoft.Storage. Defaults to Microsoft.Storage."
-  type        = string
-  default     = "Microsoft.Storage"
 }
 
 variable "containers" {


### PR DESCRIPTION
The following attributes are deprecated in ```storage_account``` terraform resource : 
- enable_blob_encryption
- enable_file_encryption
- account_encryption_source